### PR TITLE
Updating README API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ $ finepack
 For uses inside your NodeJS project, just install as normal dependency.
 
 ```js
-var finepack = require('finepack');
+var fs       = require('fs');
 var path     = require('path');
-var filename = path.basename(filepath);
+var finepack = require('finepack');
 var filepath = path.resolve('./package.json');
+var filename = path.basename(filepath);
 var filedata = fs.readFileSync(filepath, {encoding: 'utf8'});
 
 var options = {


### PR DESCRIPTION
`fs` module wasn't included (but needed for `readFileSync()`), and `filename` was always `undefined` since `filepath` wasn't defined yet.
