### PR TITLE
Setting messages to an Object instead of an Array

### DIFF
--- a/lib/Logger.coffee
+++ b/lib/Logger.coffee
@@ -7,7 +7,7 @@ module.exports = class Logger
   @types: ['error', 'warning', 'success', 'info']
 
   constructor: ->
-    @messages = []
+    @messages = {}
     @messages[type] = [] for type in Logger.types
 
   add: (type, content) ->


### PR DESCRIPTION
This should fix the `JSON.stringify()` bug.
Fixes #6 
