### PR TITLE
Changing missing message text to be a bit clearer

### DIFF
--- a/lib/Report.coffee
+++ b/lib/Report.coffee
@@ -39,7 +39,7 @@ module.exports = class Report
     cb(true, data, @logger.messages)
 
   missingMessage: (cb, data) ->
-    @logger.info("#{chalk.bold(@filename)} is near to be #{chalk.bold('fine')}. Check the file and run again.")
+    @logger.info("#{chalk.bold(@filename)} is almost #{chalk.bold('fine')}. Check the file and run again.")
     cb(true, data, @logger.messages)
 
   alreadyMessage: (cb, data) ->


### PR DESCRIPTION
Now, instead of:

> 'info: package.json is near to be fine. Check the file and run again.' 

It should be a bit clearer and say:

> 'info: package.json is almost fine. Check the file and run again.'
