### PR TITLE
Restore the correct sorting behavior, add tests to verify it

### DIFF
--- a/lib/Finepack.coffee
+++ b/lib/Finepack.coffee
@@ -13,6 +13,17 @@ DEFAULT =
   filename: ''
 
 ###
+  @description Sort the keys of an object by the order they appear in 'keyList'.
+  @note Any key that is defined in 'obj' but not in 'keyList' will be ignored.
+  * @param  {obj} object An object literal.
+###
+sortObjectKeysBy = (obj, keyList) ->
+  keyList.reduce (acc, key) -> # Function, first argument of reduce().
+    acc[key] = obj[key]
+    acc
+  , {} # Object, second argument of reduce(), initial value of 'acc'.
+
+###
   @description Organize the keys of a JSON file.
   * @param  {string} data
   * @param  {opts} object
@@ -53,11 +64,21 @@ module.exports = (data, opts = {}, cb) ->
   input = sort input, opts.sortOptions
 
   # After sorting, we move some fields in new positions for esthetic effect.
-  compareFunction = (a, b) -> KEYWORDS.sort.indexOf(a) - KEYWORDS.sort.indexOf(b)
-  output = Object.keys(input).sort(compareFunction).reduce (acc, key) ->
-   acc[key] = input[key]
-   acc
-  , {} # Object, second argument of reduce(), initial value of 'acc'.
+  # First, we get all 'KEYWORDS.sort' that are in 'input'; no need to sort them,
+  # they are already in the correct order defined in './lib/Keywords.coffee'.
+  specialKeys = KEYWORDS.sort.filter (k) ->
+    Object.prototype.hasOwnProperty.call(input, k)
+
+  # We get all the "non-special" keys in 'input'. We don't sort them, they
+  # were alphabetically sorted (or maybe sorted in a custom order, if the user
+  # passed a 'compareFunction') by 'sort-keys-recursive' (see above).
+  otherKeys = Object.keys(input).filter (e) -> KEYWORDS.sort.indexOf(e) == -1
+
+  # We add the "special" keys before the rest of the keys.
+  orderedInputKeys = [specialKeys..., otherKeys...]
+
+  # We sort the keys in 'input' by the order they appear in 'orderedInputKeys'.
+  output = sortObjectKeysBy input, orderedInputKeys
 
   return report.missingMessage(cb, output) if validation.missing
   return report.alreadyMessage(cb, output) if JSONisEqual data, output

--- a/test/fixtures/pkg_custom_properties.json
+++ b/test/fixtures/pkg_custom_properties.json
@@ -21,6 +21,12 @@
     "cli",
     "package"
   ],
+  "secondCustomKey": {
+    "anArray": [
+      "foo",
+      "bar"
+    ]
+  },
   "license": "MIT",
   "main": "fishpack.js",
   "preferGlobal": true,
@@ -45,5 +51,11 @@
         }
       ]
     }
+  },
+  "thirdCustomKey": {
+    "anArray": [
+      "bar",
+      "baz"
+    ]
   }
 }

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -100,6 +100,38 @@ describe 'Finepack ::', ->
         output.keywords.should.be.eql([ 'cleanup', 'cli', 'package', 'tool' ])
         done()
 
+    it 'sort \'special\' keys before the other keys', (done) ->
+      data = fs.readFileSync @fileCustomProperty, {encoding: 'utf8'}
+      options = filename: 'pkg.json'
+
+      Finepack data, options, (err, output, messages) ->
+        should(err).be.null()
+        output.should.be.Object()
+
+        # Expect the three keys not included in './lib/Keywords.coffee' > 'sort'
+        # to be at the end of the 'output' object and sorted alphabetically.
+        expectedKeys = ['aCustomKey', 'secondCustomKey', 'thirdCustomKey']
+        Object.keys(output).slice(-3).should.be.eql(expectedKeys)
+
+        done()
+
+    it 'sort \'special\' keys before the other keys (+ \'compareFunction\')', (done) ->
+      data = fs.readFileSync @fileCustomProperty, {encoding: 'utf8'}
+      compareFunction = (a, b) -> a < b
+      options = filename: 'pkg.json', sortOptions:{ compareFunction}
+
+      Finepack data, options, (err, output, messages) ->
+        should(err).be.null()
+        output.should.be.Object()
+
+        # Expect the three keys not included in './lib/Keywords.coffee' > 'sort'
+        # to be at the end of the 'output' object. Also expect them to have been
+        # sorted in reverse alphabetical order by 'compareFunction'.
+        expectedKeys = ['thirdCustomKey', 'secondCustomKey', 'aCustomKey']
+        Object.keys(output).slice(-3).should.be.eql(expectedKeys)
+
+        done()
+
     it 'validate file > options.sortOptions.compareFunction', (done) ->
       data = fs.readFileSync @fileCustomProperty, {encoding: 'utf8'}
       compareFunction = (a, b) -> a > b


### PR DESCRIPTION
I accidentally broke the correct sorting behavior in #36 (sort keys in './lib/Keywords.coffee' > 'sort' before the other keys). :worried:

- Restore the correct sorting behavior.
- Add two new tests to verify the expected behavior.